### PR TITLE
Codeflow analysis bug fixes

### DIFF
--- a/vivisect/analysis/__init__.py
+++ b/vivisect/analysis/__init__.py
@@ -20,7 +20,9 @@ def addAnalysisModules(vw):
 
         if arch == 'i386':
 
-            vw.addImpApi('windows','i386')
+            vw.addImpApi('windows', 'i386')
+            if plat == 'winkern':
+                vw.addImpApi('winkern', 'i386')
 
             viv_analysis_i386.addEntrySigs(vw)
             vw.addStructureModule('win32', 'vstruct.defs.win32')
@@ -28,7 +30,10 @@ def addAnalysisModules(vw):
 
         elif arch == 'amd64':
 
-            vw.addImpApi('windows','amd64')
+            vw.addImpApi('windows', 'amd64')
+            if plat == 'winkern':
+                vw.addImpApi('winkern', 'amd64')
+
             vw.addStructureModule('ntdll', 'vstruct.defs.windows.win_6_1_amd64.ntdll')
 
         vw.addConstModule('vstruct.constants.ntstatus')

--- a/vivisect/impapi/winkern/amd64.py
+++ b/vivisect/impapi/winkern/amd64.py
@@ -1,0 +1,26 @@
+# APIs for Windows 64-bit ntoskrnl library.
+# Built as a delta from the 32-bit version.
+# Format:  retval, rettype, callconv, exactname, arglist(type, name)
+#          arglist type is one of ['int', 'void *']
+#          arglist name is one of [None, 'funcptr', 'obj', 'ptr']
+
+# List the normalized name of any 32-bit functions to omit.
+api_32_omits = []
+
+# Define any functions specific to 64-bit.
+api_64_adds = {
+    }
+
+
+# Build from the 32-bit API, skipping omits, changing the calling convention,
+# and adding any specific 64-bit functions.
+apitypes = {}
+api = {}
+
+import vivisect.impapi.winkern.i386 as m32
+for name in m32.api.iterkeys():
+    if name in api_32_omits:
+        continue
+    (rtype,rname,cconv,cname,cargs) = m32.api[name]
+    api[name] = (rtype, rname, 'msx64call', cname, cargs)
+api.update(api_64_adds)

--- a/vivisect/impapi/winkern/i386.py
+++ b/vivisect/impapi/winkern/i386.py
@@ -1,3 +1,8 @@
+# APIs for Windows 32-bit ntoskrnl library.
+# Format:  retval, rettype, callconv, exactname, arglist(type, name)
+#          arglist type is one of ['int', 'void *']
+#          arglist name is one of [None, 'funcptr', 'obj', 'ptr']
+
 apitypes = {
 }
 


### PR DESCRIPTION
All fixes were validated against a FireEye 6500+ sample regression test.  About 2% of functions are affected.  The fixes (with FireEye JIRA ticket numbers):

F-788  Handle no-return-API calls in code flow analysis, such as ExitProcess() and ExitThread().  A call should terminate a basic block with no return.
F-792  Include ntoskrnl.exe API call definitions when the PE subsystem is 1 = native/driver.  This lets symbolic execution assign the correct number of call arguments, instead of guessing from emulation.
F-662  Allow PE header to be less than 4k page size.
F-732  Allow PE .data segment to be truncated in length (smaller than the declared size in the header).